### PR TITLE
Ensure attachments have names

### DIFF
--- a/gmail_client/message.py
+++ b/gmail_client/message.py
@@ -101,10 +101,8 @@ class ParsedEmail(object):
 
             if dispositions[0].lower() in ["attachment", "inline"]:
                 return True
-            else:
-                return False
-        else:
-            return False
+        
+        return False
 
     @staticmethod
     def is_multi_part(p):


### PR DESCRIPTION
A part of an email not having a filename can't be an attachment. This stops random HTML getting interpreted as attachments.
