### PR TITLE
if an element of an email's content disposition is something other than ...

### DIFF
--- a/gmail_client/message.py
+++ b/gmail_client/message.py
@@ -95,12 +95,13 @@ class ParsedEmail(object):
     def is_attachment(p):
         content_disposition = p.get("Content-Disposition", None)
         filename = p.get_filename()
-        
+
+
         if filename is not None \
                 or (content_disposition is not None and
-                    content_disposition.find('attachment')):
+                        content_disposition.find('attachment') > -1):
             return True
-        
+
         return False
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "gmail-client",
-    version = "0.0.7.4",
+    version = "0.0.7.5",
     author = "Wilberto Morales",
     author_email = "wilbertomorales777@gmail.com",
     description = ("A Pythonic interface for Google Mail. Based of https://github.com/charlierguo/gmai"),


### PR DESCRIPTION
...'attachment', don't assume it's an attachment; this was making us think random pieces of 'inline' html were attachments with a filename of 'None', which in turn get represented as attachments with no filetype, which (in PWM) causes us to send an error email no matter if there are valid docs; also, this was supposed to already be fixed, but there was a trivial bug in the code of that PR, see comments on: https://github.com/wilbertom/gmail_client/pull/12