### PR TITLE
Correctly decode subject header in gmail client

### DIFF
--- a/gmail_client/message.py
+++ b/gmail_client/message.py
@@ -48,7 +48,7 @@ def parse_labels(headers):
 def parse_subject(encoded_header):
 
     if encoded_header is not None:
-        dh = encoded_header.encode('UTF-8')
+        dh = decode_email_header(encoded_header)
     else:
         dh = ''
 

--- a/gmail_client/message.py
+++ b/gmail_client/message.py
@@ -310,13 +310,13 @@ class Message(object):
                 self._parse(self.raw)
                 return self.message
             else:
-                return self.forced_fetch()
+                return self.forced_fetch(parse=True)
 
     @property
     def has_attachments(self):
         return len(self.attachments) > 0
 
-    def forced_fetch(self, parse=False):
+    def forced_fetch(self, parse=True):
         _, results = self.gmail.imap.uid('FETCH', self.uid, '(BODY.PEEK[] FLAGS X-GM-THRID X-GM-MSGID X-GM-LABELS)')
         self.raw = results[0]
         if parse:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "gmail-client",
-    version = "0.0.7.7",
+    version = "0.0.8.0",
     author = "Wilberto Morales",
     author_email = "wilbertomorales777@gmail.com",
     description = ("A Pythonic interface for Google Mail. Based of https://github.com/charlierguo/gmai"),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "gmail-client",
-    version = "0.0.8.0",
+    version = "0.0.8.1",
     author = "Wilberto Morales",
     author_email = "wilbertomorales777@gmail.com",
     description = ("A Pythonic interface for Google Mail. Based of https://github.com/charlierguo/gmai"),


### PR DESCRIPTION
I just realized this little fix was necessary.